### PR TITLE
Add multimodal emotion recognition scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# urop
+# Multimodal Speech Emotion Recognition
+
+This project provides simple scripts to train and test an emotion recognition model that uses both audio and text information. It targets the [KEMDy20](https://nanum.etri.re.kr/share/kjnoh2/KEMDy20?lang=En_us) dataset but can be adapted to any dataset organized as a CSV file.
+
+## Dataset preparation
+
+1. Download the KEMDy20 dataset manually from the ETRI website.
+2. Create a CSV file with the following columns:
+   - `path`: path to each WAV file.
+   - `text`: transcript of the utterance.
+   - `label`: emotion label (e.g., `angry`, `sad`, `neutral`, etc.).
+3. Split the CSV into training and validation files, e.g. `train.csv` and `valid.csv`.
+
+## Training
+
+Install dependencies (Python 3.12 recommended):
+
+```bash
+pip install torch transformers datasets pandas sounddevice speechrecognition pocketsphinx tqdm
+```
+
+Run training:
+
+```bash
+python train.py --train_csv train.csv --valid_csv valid.csv --output_dir checkpoints
+```
+
+The script saves `model.pt` in the specified output directory.
+
+## Testing interactively
+
+After training, run the demo application:
+
+```bash
+python app.py --model checkpoints/model.pt
+```
+
+1. Press `Ctrl+C` to stop recording.
+2. The program prints the recognized text and the predicted emotion.
+
+The demo uses `pocketsphinx` for offline speech recognition. You can replace it with any preferred speech-to-text system by modifying `app.py`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,79 @@
+import argparse
+import queue
+import sys
+
+import numpy as np
+import sounddevice as sd
+import speech_recognition as sr
+import torch
+from transformers import AutoTokenizer
+
+from model import AudioTextEmotionModel
+
+SAMPLE_RATE = 16000
+
+
+def record_audio(duration=None):
+    q = queue.Queue()
+
+    def callback(indata, frames, time, status):
+        q.put(indata.copy())
+
+    with sd.InputStream(samplerate=SAMPLE_RATE, channels=1, callback=callback):
+        print('Recording... Press Ctrl+C to stop.')
+        frames = []
+        try:
+            while True:
+                frames.append(q.get())
+                if duration and len(frames) * 1024 / SAMPLE_RATE >= duration:
+                    break
+        except KeyboardInterrupt:
+            print('Recording stopped.')
+    audio = np.concatenate(frames, axis=0)
+    return audio.squeeze()
+
+
+def recognize_text(audio):
+    recognizer = sr.Recognizer()
+    audio_data = sr.AudioData(audio.tobytes(), SAMPLE_RATE, 2)
+    try:
+        text = recognizer.recognize_sphinx(audio_data)
+    except sr.UnknownValueError:
+        text = ''
+    return text
+
+
+def main(args):
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    checkpoint = torch.load(args.model, map_location=device)
+    tokenizer = AutoTokenizer.from_pretrained(args.text_model)
+    model = AudioTextEmotionModel(args.text_model, args.audio_model, num_labels=len(checkpoint['label2id']))
+    model.load_state_dict(checkpoint['model_state'])
+    model.to(device)
+    label2id = checkpoint['label2id']
+    id2label = {v: k for k, v in label2id.items()}
+
+    while True:
+        audio = record_audio()
+        waveform = torch.tensor(audio, dtype=torch.float32)
+        text = recognize_text(audio)
+        print('Transcription:', text)
+
+        inputs = tokenizer(text, return_tensors='pt', padding='max_length', truncation=True, max_length=128)
+        with torch.no_grad():
+            output = model(
+                input_ids=inputs['input_ids'].to(device),
+                attention_mask=inputs['attention_mask'].to(device),
+                input_values=waveform.unsqueeze(0).to(device)
+            )
+            pred = output['logits'].argmax(dim=1).item()
+            print('Predicted emotion:', id2label[pred])
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model', required=True)
+    parser.add_argument('--text_model', default='distilbert-base-uncased')
+    parser.add_argument('--audio_model', default='facebook/wav2vec2-base-960h')
+    args = parser.parse_args()
+    main(args)

--- a/kemdy_dataset.py
+++ b/kemdy_dataset.py
@@ -1,0 +1,41 @@
+import torch
+from torch.utils.data import Dataset
+import torchaudio
+import pandas as pd
+
+class KemdyDataset(Dataset):
+    def __init__(self, csv_path, tokenizer, label2id=None, max_length=128, sample_rate=16000):
+        self.data = pd.read_csv(csv_path)
+        self.tokenizer = tokenizer
+        self.max_length = max_length
+        self.sample_rate = sample_rate
+        if label2id is None:
+            labels = sorted(self.data['label'].unique())
+            self.label2id = {l: i for i, l in enumerate(labels)}
+        else:
+            self.label2id = label2id
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        row = self.data.iloc[idx]
+        wav_path = row['path']
+        text = row['text']
+        label = row['label']
+
+        waveform, sr = torchaudio.load(wav_path)
+        if sr != self.sample_rate:
+            waveform = torchaudio.functional.resample(waveform, sr, self.sample_rate)
+        waveform = waveform.squeeze(0)
+
+        text_inputs = self.tokenizer(text, truncation=True, padding='max_length',
+                                    max_length=self.max_length, return_tensors='pt')
+        label_id = self.label2id[label]
+
+        return {
+            'input_values': waveform,
+            'input_ids': text_inputs['input_ids'].squeeze(0),
+            'attention_mask': text_inputs['attention_mask'].squeeze(0),
+            'labels': torch.tensor(label_id, dtype=torch.long)
+        }

--- a/model.py
+++ b/model.py
@@ -1,0 +1,21 @@
+import torch
+import torch.nn as nn
+from transformers import AutoModel, Wav2Vec2Model
+
+class AudioTextEmotionModel(nn.Module):
+    def __init__(self, text_model_name='distilbert-base-uncased', audio_model_name='facebook/wav2vec2-base-960h', num_labels=4):
+        super().__init__()
+        self.text_model = AutoModel.from_pretrained(text_model_name)
+        self.audio_model = Wav2Vec2Model.from_pretrained(audio_model_name)
+        hidden_size = self.text_model.config.hidden_size + self.audio_model.config.hidden_size
+        self.classifier = nn.Linear(hidden_size, num_labels)
+
+    def forward(self, input_ids, attention_mask, input_values, labels=None):
+        text_out = self.text_model(input_ids=input_ids, attention_mask=attention_mask).last_hidden_state[:,0]
+        audio_out = self.audio_model(input_values=input_values).last_hidden_state[:,0]
+        hidden = torch.cat([text_out, audio_out], dim=1)
+        logits = self.classifier(hidden)
+        loss = None
+        if labels is not None:
+            loss = nn.functional.cross_entropy(logits, labels)
+        return {'loss': loss, 'logits': logits}

--- a/train.py
+++ b/train.py
@@ -1,0 +1,89 @@
+import argparse
+import os
+from tqdm import tqdm
+import torch
+from torch.utils.data import DataLoader
+from transformers import AutoTokenizer
+
+from kemdy_dataset import KemdyDataset
+from model import AudioTextEmotionModel
+
+
+def collate_fn(batch):
+    audios = [b['input_values'] for b in batch]
+    input_ids = [b['input_ids'] for b in batch]
+    attention_mask = [b['attention_mask'] for b in batch]
+    labels = torch.stack([b['labels'] for b in batch])
+
+    audio_padded = torch.nn.utils.rnn.pad_sequence(audios, batch_first=True)
+    ids_padded = torch.nn.utils.rnn.pad_sequence(input_ids, batch_first=True, padding_value=tokenizer.pad_token_id)
+    mask_padded = torch.nn.utils.rnn.pad_sequence(attention_mask, batch_first=True, padding_value=0)
+
+    return {'input_values': audio_padded,
+            'input_ids': ids_padded,
+            'attention_mask': mask_padded,
+            'labels': labels}
+
+
+def train(args):
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    global tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(args.text_model)
+
+    train_ds = KemdyDataset(args.train_csv, tokenizer)
+    valid_ds = KemdyDataset(args.valid_csv, tokenizer, label2id=train_ds.label2id)
+    num_labels = len(train_ds.label2id)
+
+    model = AudioTextEmotionModel(args.text_model, args.audio_model, num_labels)
+    model.to(device)
+
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True, collate_fn=collate_fn)
+    valid_loader = DataLoader(valid_ds, batch_size=args.batch_size, shuffle=False, collate_fn=collate_fn)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+
+    for epoch in range(args.epochs):
+        model.train()
+        total_loss = 0
+        for batch in tqdm(train_loader, desc=f'Training {epoch}'):
+            batch = {k: v.to(device) for k, v in batch.items()}
+            outputs = model(**batch)
+            loss = outputs['loss']
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+            total_loss += loss.item()
+        avg_loss = total_loss / len(train_loader)
+        print(f'Epoch {epoch} Train loss: {avg_loss:.4f}')
+
+        model.eval()
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for batch in valid_loader:
+                batch = {k: v.to(device) for k, v in batch.items()}
+                outputs = model(**batch)
+                preds = outputs['logits'].argmax(dim=1)
+                correct += (preds == batch['labels']).sum().item()
+                total += preds.size(0)
+        acc = correct / total if total else 0
+        print(f'Epoch {epoch} Val accuracy: {acc:.4f}')
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    model_path = os.path.join(args.output_dir, 'model.pt')
+    torch.save({'model_state': model.state_dict(), 'label2id': train_ds.label2id}, model_path)
+    print('Model saved to', model_path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--train_csv', required=True)
+    parser.add_argument('--valid_csv', required=True)
+    parser.add_argument('--text_model', default='distilbert-base-uncased')
+    parser.add_argument('--audio_model', default='facebook/wav2vec2-base-960h')
+    parser.add_argument('--output_dir', default='checkpoints')
+    parser.add_argument('--batch_size', type=int, default=4)
+    parser.add_argument('--epochs', type=int, default=3)
+    parser.add_argument('--lr', type=float, default=1e-5)
+    args = parser.parse_args()
+    train(args)


### PR DESCRIPTION
## Summary
- implement dataset loader and classification model
- add training script for audio+text emotion classification
- add interactive demo using microphone input
- document how to prepare the dataset and run training/inference

## Testing
- `python -m py_compile app.py model.py train.py kemdy_dataset.py`
- `python train.py --help`
- `python app.py --help` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_686616d89d44832d8fd9a24486bb6d09